### PR TITLE
Rework the code for hex-based protocol

### DIFF
--- a/Joystick.c
+++ b/Joystick.c
@@ -228,6 +228,8 @@ void HID_Task(void) {
 		Endpoint_Write_Stream_LE(&JoystickInputData, sizeof(JoystickInputData), NULL);
 		// We then send an IN packet on this endpoint.
 		Endpoint_ClearIN();
+		// Inform host that a packet was sent.
+		printf("U");
 
 		/* Clear the report data afterwards */
 		// memset(&JoystickInputData, 0, sizeof(JoystickInputData));

--- a/bridge.py
+++ b/bridge.py
@@ -129,7 +129,11 @@ if __name__ == '__main__':
                         replay.write(message + b'\n')
                 ser.write(message + b'\n')
 
-            while(ser.read(1) != b'U'):
-                pass
+            while True:
+                response = ser.read(1)
+                if response == b'U':
+                    break
+                elif response == b'X':
+                    print('Arduino reported buffer overrun.')
 
             pbar.update()

--- a/bridge.py
+++ b/bridge.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+
+import argparse
+
+import sdl2
+import sdl2.ext
+import struct
+import binascii
+import serial
+import time
+
+def enumerate_controllers():
+    print('Controllers connected to this system:')
+    for n in range(sdl2.SDL_NumJoysticks()):
+        name = sdl2.SDL_JoystickNameForIndex(n)
+        if name is not None:
+            name = name.decode('utf8')
+        print(n, ':', name)
+    print('Note: These are numbered by connection order. Numbers will change if you unplug a controller.')
+
+
+def get_controller(c):
+    try:
+        n = int(c, 10)
+        return sdl2.SDL_GameControllerOpen(n)
+    except ValueError:
+        for n in range(sdl2.SDL_NumJoysticks()):
+            name = sdl2.SDL_JoystickNameForIndex(n)
+            if name is not None:
+                name = name.decode('utf8')
+                if name == c:
+                    return sdl2.SDL_GameControllerOpen(n)
+        raise Exception('Controller not found: %s'.format(c))
+
+
+buttonmapping = [
+    sdl2.SDL_CONTROLLER_BUTTON_Y, # Y
+    sdl2.SDL_CONTROLLER_BUTTON_B, # B
+    sdl2.SDL_CONTROLLER_BUTTON_A, # A
+    sdl2.SDL_CONTROLLER_BUTTON_X, # X
+    sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER, # L
+    sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, #R
+    sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK, # ZL
+    sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK, # ZR
+    sdl2.SDL_CONTROLLER_BUTTON_BACK, # SELECT
+    sdl2.SDL_CONTROLLER_BUTTON_START, # START
+    sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK, # LCLICK
+    sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK, # RCLICK
+    sdl2.SDL_CONTROLLER_BUTTON_GUIDE, # HOME
+    sdl2.SDL_CONTROLLER_BUTTON_GUIDE, # CAPTURE
+]
+
+
+
+def send_state(ser, controller):
+    buttons = sum([sdl2.SDL_GameControllerGetButton(controller, b)<<n for n,b in enumerate(buttonmapping)])
+    hat = 0
+    lx = (sdl2.SDL_GameControllerGetAxis(controller, 0) >> 8) + 128
+    ly = (sdl2.SDL_GameControllerGetAxis(controller, 1) >> 8) + 128
+    rx = (sdl2.SDL_GameControllerGetAxis(controller, 2) >> 8) + 128
+    ry = (sdl2.SDL_GameControllerGetAxis(controller, 3) >> 8) + 128
+
+    bytes = struct.pack('>BHBBBB', hat, buttons, lx, ly, rx, ry)
+    message = binascii.hexlify(bytes)
+    ser.write(message + b'\n')
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-l', '--list-controllers', action='store_true', help='Display a list of controllers attached to the system.')
+    parser.add_argument('-c', '--controller', type=str, default='0', help='Controller to use. Default: 0.')
+    parser.add_argument('-b', '--baud-rate', type=int, default=115200, help='Baud rate. Default: 57600.')
+    parser.add_argument('-p', '--port', type=str, default='/dev/ttyUSB0', help='Serial port. Default: /dev/ttyUSB0.')
+
+    args = parser.parse_args()
+
+    sdl2.SDL_Init(sdl2.SDL_INIT_GAMECONTROLLER)
+
+    if args.list_controllers:
+        enumerate_controllers()
+        exit(0)
+
+
+    controller = get_controller(args.controller)
+    try:
+        print('Using "{:s}" for input.'.format(sdl2.SDL_JoystickName(sdl2.SDL_GameControllerGetJoystick(controller)).decode('utf8')))
+    except AttributeError:
+        print('Using controller {:s} for input.'.format(args.controller))
+
+    ser = serial.Serial(args.port, args.baud_rate)
+    print('Using {:s} at {:d} baud for comms.'.format(args.port, args.baud_rate))
+
+    while True:
+        sent = False
+        for event in sdl2.ext.get_events():
+            pass
+
+        if not sent:
+            send_state(ser, controller)
+
+        time.sleep(0.005)

--- a/bridge.py
+++ b/bridge.py
@@ -53,7 +53,7 @@ buttonmapping = [
 
 
 
-def send_state(ser, controller):
+def get_state(ser, controller):
     buttons = sum([sdl2.SDL_GameControllerGetButton(controller, b)<<n for n,b in enumerate(buttonmapping)])
     hat = 0
     lx = (sdl2.SDL_GameControllerGetAxis(controller, 0) >> 8) + 128
@@ -62,8 +62,7 @@ def send_state(ser, controller):
     ry = (sdl2.SDL_GameControllerGetAxis(controller, 3) >> 8) + 128
 
     bytes = struct.pack('>BHBBBB', hat, buttons, lx, ly, rx, ry)
-    message = binascii.hexlify(bytes)
-    ser.write(message + b'\n')
+    return binascii.hexlify(bytes)
 
 
 if __name__ == '__main__':
@@ -103,7 +102,9 @@ if __name__ == '__main__':
             pass
 
         if not sent:
-            send_state(ser, controller)
+            message = get_state(ser, controller)
+            # TODO: write message to a replay file
+            ser.write(message + b'\n')
 
         while(ser.read(1) != b'U'):
             pass

--- a/bridge.py
+++ b/bridge.py
@@ -10,6 +10,8 @@ import binascii
 import serial
 import time
 
+from tqdm import tqdm
+
 def enumerate_controllers():
     print('Controllers connected to this system:')
     for n in range(sdl2.SDL_NumJoysticks()):
@@ -106,27 +108,28 @@ if __name__ == '__main__':
     ser = serial.Serial(args.port, args.baud_rate, timeout=None)
     print('Using {:s} at {:d} baud for comms.'.format(args.port, args.baud_rate))
 
+    with tqdm(unit=' update') as pbar:
 
-    while True:
-        sent = False
-        for event in sdl2.ext.get_events():
-            # we have to fetch the events from SDL in order for the controller
-            # state to be updated. we may also want to conditionally run an
-            # immediate update on certain events, so as to avoid dropping
-            # very fast button presses. this is why the "sent" variable exists.
-            # for now though, just pass.
-            pass
+        while True:
+            sent = False
+            for event in sdl2.ext.get_events():
+                # we have to fetch the events from SDL in order for the controller
+                # state to be updated. we may also want to conditionally run an
+                # immediate update on certain events, so as to avoid dropping
+                # very fast button presses. this is why the "sent" variable exists.
+                # for now though, just pass.
+                pass
 
-        if not sent:
-            if args.playback is not None:
-                message = replay.readline()
-            else:
-                message = get_state(ser, controller)
-                if replay is not None:
-                    replay.write(message + b'\n')
-            ser.write(message + b'\n')
+            if not sent:
+                if args.playback is not None:
+                    message = replay.readline()
+                else:
+                    message = get_state(ser, controller)
+                    if replay is not None:
+                        replay.write(message + b'\n')
+                ser.write(message + b'\n')
 
-        while(ser.read(1) != b'U'):
-            pass
-        
-#        time.sleep(0.005)
+            while(ser.read(1) != b'U'):
+                pass
+
+            pbar.update()

--- a/bridge.py
+++ b/bridge.py
@@ -95,6 +95,11 @@ if __name__ == '__main__':
     while True:
         sent = False
         for event in sdl2.ext.get_events():
+            # we have to fetch the events from SDL in order for the controller
+            # state to be updated. we may also want to conditionally run an
+            # immediate update on certain events, so as to avoid dropping
+            # very fast button presses. this is why the "sent" variable exists.
+            # for now though, just pass.
             pass
 
         if not sent:

--- a/bridge.py
+++ b/bridge.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
     except AttributeError:
         print('Using controller {:s} for input.'.format(args.controller))
 
-    ser = serial.Serial(args.port, args.baud_rate)
+    ser = serial.Serial(args.port, args.baud_rate, timeout=None)
     print('Using {:s} at {:d} baud for comms.'.format(args.port, args.baud_rate))
 
     while True:
@@ -105,4 +105,7 @@ if __name__ == '__main__':
         if not sent:
             send_state(ser, controller)
 
-        time.sleep(0.005)
+        while(ser.read(1) != b'U'):
+            pass
+        
+#        time.sleep(0.005)

--- a/makefile
+++ b/makefile
@@ -35,3 +35,9 @@ include $(LUFA_PATH)/Build/lufa_dfu.mk
 include $(LUFA_PATH)/Build/lufa_hid.mk
 include $(LUFA_PATH)/Build/lufa_avrdude.mk
 include $(LUFA_PATH)/Build/lufa_atprogram.mk
+
+.PHONY: flash
+flash:
+	sudo dfu-programmer $(MCU) erase
+	sudo dfu-programmer $(MCU) flash $(TARGET).hex
+	sudo dfu-programmer $(MCU) reset || true


### PR DESCRIPTION
This changes Joystick.c to use hex strings which halves the amount of data transmitted. It also refactors the interrupt service routine to be more robust, by using a circular buffer to minimize time spent inside the ISR. This code is stable at 115200 baud.

The new protocol is implemented on PC side by bridge.py which needs pysdl2 and python 3. The PC
side software is not fully implemented: hat and a couple of buttons are not available (the missing buttons are double mapped so some PC buttons trigger two Switch buttons, hat is not implemented at all.)

See individual commit messages for details.